### PR TITLE
Fix linux build

### DIFF
--- a/engine/fsposix/FileSystemPosix.cpp
+++ b/engine/fsposix/FileSystemPosix.cpp
@@ -6,6 +6,7 @@
 #include <fnmatch.h>
 #include <sys/stat.h>
 #include <string.h>
+#include <stdexcept>
 
 using namespace FS;
 using namespace FS::detail;

--- a/external/gtest/src/gtest-death-test.cc
+++ b/external/gtest/src/gtest-death-test.cc
@@ -997,14 +997,14 @@ static int ExecDeathTestChildMain(void* child_arg) {
 // correct answer.
 void StackLowerThanAddress(const void* ptr, bool* result) GTEST_NO_INLINE_;
 void StackLowerThanAddress(const void* ptr, bool* result) {
-  int dummy;
+  int dummy = 0;
   *result = (&dummy < ptr);
 }
 
 // Make sure AddressSanitizer does not tamper with the stack here.
 GTEST_ATTRIBUTE_NO_SANITIZE_ADDRESS_
 bool StackGrowsDown() {
-  int dummy;
+  int dummy = 0;
   bool result;
   StackLowerThanAddress(&dummy, &result);
   return result;


### PR DESCRIPTION
Fixes for the following:
- warning: `dummy` may be used uninitialized
- error: `runtime_error` is not a member of `std`